### PR TITLE
Uppercase JSON breaks requirement in Ruby 2.2

### DIFF
--- a/lib/iiif_s3.rb
+++ b/lib/iiif_s3.rb
@@ -1,5 +1,5 @@
 require 'csv'
-require 'JSON'
+require 'json'
 
 require "iiif_s3/version"
 require "iiif_s3/errors"


### PR DESCRIPTION
This is  a trifling change, but I need it to make things work in https://github.com/pbinkley/jekyll-iiif . Thanks for iiif_s3, it's a great piece of work. 